### PR TITLE
Fix auth middleware login paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -5316,7 +5316,15 @@ async def auth_middleware(request: Request, call_next):
     English - Authentication middleware for token verification
     """
     # Skip auth for login routes and public endpoints
-    if request.url.path in ["/api/login", "/api/register", "/api/admin/login", "/", "/admin"]:
+    if request.url.path in [
+        "/api/login",
+        "/api/register",
+        "/api/auth/login",
+        "/api/auth/register",
+        "/api/admin/login",
+        "/",
+        "/admin",
+    ]:
         return await call_next(request)
     
     # Skip auth for static files


### PR DESCRIPTION
## Summary
- update the auth middleware to allow new `/api/auth/login` and `/api/auth/register` endpoints

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684996df9a248322aae31ee76b890bc1