### PR TITLE
Fix admin login token name

### DIFF
--- a/app.py
+++ b/app.py
@@ -4020,7 +4020,7 @@ async function loadUsers() {
                 }
 
                 const data = await response.json();
-                authToken = data.access_token;
+                authToken = data.token;
                 localStorage.setItem('jyotiflow_admin_token', authToken);
                 showToast('Login successful', 'success');
                 checkAuth();


### PR DESCRIPTION
## Summary
- update client-side admin login logic to use `data.token`

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684997253cd8832293d54306e45f6e7f