### PR TITLE
Fix SKU mismatch for session start

### DIFF
--- a/app.py
+++ b/app.py
@@ -1509,7 +1509,7 @@ def clarity_page():
                             'Content-Type': 'application/json',
                         },
                         body: JSON.stringify({
-                            service_type: 'clarity',
+                            sku: 'clarity',
                             question: question,
                             birth_date: birthDate,
                             birth_time: birthTime,
@@ -1838,7 +1838,7 @@ def astrolove_page():
                         'Content-Type': 'application/json',
                     },
                     body: JSON.stringify({
-                        service_type: 'love',
+                        sku: 'love',
                         question: question,
                         relationship_status: relationshipStatus,
                         birth_date: birthDate,
@@ -2249,7 +2249,7 @@ def r3live_page():
                             'Content-Type': 'application/json',
                         },
                         body: JSON.stringify({
-                            service_type: 'premium',
+                            sku: 'premium',
                             question: question,
                             birth_date: birthDate,
                             birth_time: birthTime,
@@ -2676,7 +2676,7 @@ def daily_page():
                             'Content-Type': 'application/json',
                         },
                         body: JSON.stringify({
-                            service_type: 'elite',
+                            sku: 'elite',
                             goals: goals,
                             birth_date: birthDate,
                             birth_time: birthTime,


### PR DESCRIPTION
## Summary
- fix Clarity/Love/Premium/Elite forms to send `sku` instead of `service_type`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68499d7e61848322871117d118924f09