### PR TITLE
Add auth token headers on session pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1495,6 +1495,12 @@ def clarity_page():
                 const birthDate = document.getElementById('birthDate').value;
                 const birthTime = document.getElementById('birthTime').value;
                 const birthPlace = document.getElementById('birthPlace').value;
+
+                const token = localStorage.getItem('jyoti_token');
+                if (!token) {
+                    window.location.href = '/login';
+                    return;
+                }
                 
                 // Show loading
                 const resultDiv = document.getElementById('guidanceResult');
@@ -1507,6 +1513,7 @@ def clarity_page():
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
+                            'Authorization': 'Bearer ' + token
                         },
                         body: JSON.stringify({
                             sku: 'clarity',
@@ -1824,6 +1831,12 @@ def astrolove_page():
             const birthTime = document.getElementById('birthTime').value;
             const birthPlace = document.getElementById('birthPlace').value;
             const partnerBirthDate = document.getElementById('partnerBirthDate').value;
+
+            const token = localStorage.getItem('jyoti_token');
+            if (!token) {
+                window.location.href = '/login';
+                return;
+            }
             
             // Show loading
             const resultDiv = document.getElementById('guidanceResult');
@@ -1836,6 +1849,7 @@ def astrolove_page():
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + token
                     },
                     body: JSON.stringify({
                         sku: 'love',
@@ -2235,6 +2249,12 @@ def r3live_page():
                 const lifeStage = document.getElementById('lifeStage').value;
                 const priorityArea = document.getElementById('priorityArea').value;
                 const context = document.getElementById('context').value;
+
+                const token = localStorage.getItem('jyoti_token');
+                if (!token) {
+                    window.location.href = '/login';
+                    return;
+                }
                 
                 // Show loading
                 const resultDiv = document.getElementById('guidanceResult');
@@ -2247,6 +2267,7 @@ def r3live_page():
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
+                            'Authorization': 'Bearer ' + token
                         },
                         body: JSON.stringify({
                             sku: 'premium',
@@ -2662,6 +2683,12 @@ def daily_page():
                 const lifeFocus = document.getElementById('lifeFocus').value;
                 const guidanceTime = document.getElementById('guidanceTime').value;
                 const challenges = document.getElementById('challenges').value;
+
+                const token = localStorage.getItem('jyoti_token');
+                if (!token) {
+                    window.location.href = '/login';
+                    return;
+                }
                 
                 // Show loading
                 const resultDiv = document.getElementById('guidanceResult');
@@ -2674,6 +2701,7 @@ def daily_page():
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
+                            'Authorization': 'Bearer ' + token
                         },
                         body: JSON.stringify({
                             sku: 'elite',


### PR DESCRIPTION
## Summary
- use localStorage token on session pages
- redirect to login if token missing
- send Authorization header in each `/api/session/start` fetch

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a26658688322baa0317bbaa0f265