### PR TITLE
Improve error display on session pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1518,11 +1518,11 @@ def clarity_page():
                     });
                     
                     const data = await response.json();
-                    
+
                     if (data.success) {
                         textDiv.innerHTML = data.guidance;
                     } else {
-                        textDiv.innerHTML = '🙏🏼 ' + (data.message || 'Please ensure you have sufficient credits and try again.');
+                        textDiv.innerHTML = '🙏🏼 ' + (data.error || data.message || 'An error occurred.');
                     }
                 } catch (error) {
                     textDiv.innerHTML = '🙏🏼 The cosmic energies are temporarily disrupted. Please try again in a moment.';
@@ -1853,7 +1853,7 @@ def astrolove_page():
                 if (data.success) {
                     textDiv.innerHTML = data.guidance;
                 } else {
-                    textDiv.innerHTML = '💕 ' + (data.message || 'Please ensure you have sufficient credits and try again.');
+                    textDiv.innerHTML = '💕 ' + (data.error || data.message || 'An error occurred.');
                 }
             } catch (error) {
                 textDiv.innerHTML = '💕 The cosmic love energies are temporarily disrupted. Please try again in a moment.';
@@ -2265,7 +2265,7 @@ def r3live_page():
                     if (data.success) {
                         textDiv.innerHTML = data.guidance;
                     } else {
-                        textDiv.innerHTML = '🔮 ' + (data.message || 'Please ensure you have sufficient credits and try again.');
+                        textDiv.innerHTML = '🔮 ' + (data.error || data.message || 'An error occurred.');
                     }
                 } catch (error) {
                     textDiv.innerHTML = '🔮 The cosmic energies are temporarily disrupted. Please try again in a moment.';
@@ -2692,7 +2692,7 @@ def daily_page():
                     if (data.success) {
                         textDiv.innerHTML = data.guidance;
                     } else {
-                        textDiv.innerHTML = '🌟 ' + (data.message || 'Please ensure you have sufficient credits and try again.');
+                        textDiv.innerHTML = '🌟 ' + (data.error || data.message || 'An error occurred.');
                     }
                 } catch (error) {
                     textDiv.innerHTML = '🌟 The cosmic energies are temporarily disrupted. Please try again in a moment.';


### PR DESCRIPTION
## Summary
- surface `data.error` or `data.message` from the server on all session pages

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6849a2693d508322b972ed15188eaa17